### PR TITLE
Chore/bring env var replacement inline

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM node
+FROM node:14
 
 ADD ./server/ /usr/src/app
 RUN cd /usr/src/app/; npm install

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ _Getting started with fastboot-app-server Docker_
 
 This container aims to make it easy to get a Fastboot hosted version of your application running in Docker.
 
-The appropriate way to add the container is to install `ember-fastboot` and `ember-fetch` into your project.  This will ensure that when you create a build, it will contain the necessary sources for Fastboot to take over.  In your config/environment, make sure you add a key to ENV containing something like:
+The appropriate way to add the container is to install `ember-cli-fastboot` into your project.  This will ensure that when you create a build, it will contain the necessary sources for Fastboot to take over.  In your config/environment, make sure you add a key to ENV containing something like:
 
     fastboot: {
       hostWhitelist: ["localhost","redpencil.io"]

--- a/README.md
+++ b/README.md
@@ -104,6 +104,28 @@ Create an application adapter in `/app/adapters/application.js` looking like:
 
 When running in fastboot, your adapter will now send requests to the API at `http://backend/`, which you can link to the container.
 
+
+### Configure environment variables in the frontend's container
+
+The environment variables have to be prefixed by `EMBER_` to be recognized by the service as variables to be matched. By using docker-compose, the service configuration will look like:
+
+    docker-compose.yml
+
+    frontend:
+        environment:
+            EMBER_VAR_EXAMPLE: "example-value"
+
+### Configure the frontend's variables
+
+The frontend's configuration will use `{{VAR_EXAMPLE}}` as a placeholder that will be replaced by this service at runtime.
+
+    config/environment.js
+
+    if (environment === 'production') {
+        ENV['VAR_EXAMPLE'] = '{{VAR_EXAMPLE}}'
+    }
+
+
 ## Reasoning
 
 _Background information about the approach we took_

--- a/server/server.js
+++ b/server/server.js
@@ -2,23 +2,23 @@ let FastbootAppServer = require('fastboot-app-server');
 const fs  = require('fs');
 
 // Docker Enviroment Variables
-let indexHtmlFile = fs.readFileSync("/app/index.html", "utf8");
-for( const envVar in process.env ) {
-  console.log(`Processing ${envVar}...`);
-  if( envVar.indexOf("EMBER_") === 0 ) {
-    console.log(`Replacing name ${envVar} with value ${process.env[envVar]}`);
-    indexHtmlFile = indexHtmlFile.replace( new RegExp(envVar, "g"), encodeURIComponent(process.env[envVar]) );
-  } else {
-    console.log(`Environment variable ${envVar} not recognized for replacement.  Only variables starting with EMBER_ are used.`);
-  }
+const PREFIX = "EMBER_";
+const EMBER_CONFIG = Object.entries(process.env)
+      .filter((key) => key.indexOf(PREFIX) === 0)
+      .map((key) => [key.slice(PREFIX.length), process.env[key]]);
+
+let indexHtml = fs.readFileSync("/app/index.html", "utf8");
+for (const [key, value] of EMBER_CONFIG) {
+  console.log(`Replacing name ${key} with value ${value}`);
+  indexHtml = indexHtml.replace( new RegExp(key, "g"), encodeURIComponent(value) );
 }
-fs.writeFileSync("/app/index.html", indexHtmlFile);
+fs.writeFileSync("/app/index.html", indexHtml);
 
 let fastbootAppServer = new FastbootAppServer({
   port: 80,
   distPath: "/app/",
   chunkedResponse: true,
-  sandboxGlobals: { 
+  sandboxGlobals: {
     BACKEND_URL: "http://backend/",
    }
 });


### PR DESCRIPTION
This PR brings the behaviour of fastboot-app-server in line with the other images we have, this is a breaking change.

Ember configuration can be provided via environment variables with the `EMBER_` prefix. 
The service will then chop of that prefix and replace the remaining key inside the app with the value provided, 