### PR TITLE
also replace env vars in package.json file

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ Creating a nice fastboot build then boils down to something like the following:
     COPY . .
     RUN ember build --environment production
 
-    FROM redpencil/fastboot-app-server:dev
+    FROM redpencil/fastboot-app-server
     COPY --from=builder /app/dist /app
 
 Make a build of the application so we can wire it in the docker-compose.yml
@@ -44,7 +44,7 @@ With that in place, we can wire all of this into the docker-compose.yml file
       fastboot:
         image: fastboot-frontend-relance:dev
         links:
-            - identifire:backend
+            - identifier:backend
 
 Next up is the wiring in the dispatcher.ex
 

--- a/server/server.js
+++ b/server/server.js
@@ -1,5 +1,5 @@
-let FastbootAppServer = require('fastboot-app-server');
 const fs  = require('fs');
+const FastbootAppServer = require('fastboot-app-server');
 
 // Docker Enviroment Variables
 const PREFIX = "EMBER_";
@@ -8,12 +8,15 @@ const EMBER_CONFIG = Object.entries(process.env)
       .map(([key, value]) => [key.slice(PREFIX.length), value]);
 
 let indexHtml = fs.readFileSync("/app/index.html", "utf8");
+let packageJson = fs.readFileSync("/app/package.json", "utf8");
 for (const [key, value] of EMBER_CONFIG) {
   console.log(`Replacing name ${key} with value ${value}`);
+  packageJson = packageJson.replace( new RegExp(`{{${key}}}`, "g"), value);
   indexHtml = indexHtml.replace( new RegExp(`{{${key}}}`, "g"), encodeURIComponent(value) );
   indexHtml = indexHtml.replace( new RegExp(`%7B%7B${key}%7D%7D`, "g"), encodeURIComponent(value) );
 }
 fs.writeFileSync("/app/index.html", indexHtml);
+fs.writeFileSync("app/package.json", packageJson);
 
 let fastbootAppServer = new FastbootAppServer({
   port: 80,


### PR DESCRIPTION
fastboot stores and uses the config in package.json and ignores the config
present in the meta header. We also replace the env vars in the package.json
file so pages rendered by fastboot also have the correct configuration

created as a draft because I don't have time to test it right now