### PR TITLE
move env replacement to boot script and bump fastboot

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,5 +2,5 @@ FROM node:14
 
 ADD ./server/ /usr/src/app
 RUN cd /usr/src/app/; npm install
-CMD node /usr/src/app/server.js
+CMD "/usr/src/app/boot.sh"
 EXPOSE 80

--- a/server/boot.sh
+++ b/server/boot.sh
@@ -1,0 +1,18 @@
+#!/bin/bash
+if [ -f "/app/index.html" ]
+then
+    # Replace Ember environment variables in the build of the frontend
+    PREFIX="EMBER_"
+    ENV_VARIABLES=$(env | grep "${PREFIX}")
+
+    while IFS= read -r line; do
+        ENV_VARIABLE=$(echo "$line" | sed -e "s/^$PREFIX//" | cut -f1 -d"=")
+        VALUE=$(echo "$line" | sed -e 's/[\/&]/\\&/g' | cut -d"=" -f2-)
+        echo "replacing ${ENV_VARIABLE} with ${VALUE}"
+        sed -i "s/%7B%7B$ENV_VARIABLE%7D%7D/$VALUE/g" /app/index.html
+        sed -i "s/{{$ENV_VARIABLE}}/$VALUE/g" /app/index.html
+        sed -i "s/%7B%7B$ENV_VARIABLE%7D%7D/$VALUE/g" /app/package.json
+        sed -i "s/{{$ENV_VARIABLE}}/$VALUE/g" /app/package.json
+    done <<< "$ENV_VARIABLES"
+fi
+exec node /usr/src/app/server.js

--- a/server/package.json
+++ b/server/package.json
@@ -4,8 +4,8 @@
   "description": "A fastboot running instance",
   "main": "server.js",
   "dependencies": {
-    "ember-fetch": "^8.0.1",
-    "fastboot-app-server": "^2.0.0"
+    "fastboot-app-server": "^3.3.0",
+    "ember-fetch": "^8.1.1"
   },
   "devDependencies": {},
   "scripts": {

--- a/server/server.js
+++ b/server/server.js
@@ -6,9 +6,14 @@ let fastbootAppServer = new FastbootAppServer({
   distPath: "/app/",
   chunkedResponse: false,
   gzip: true,
-  sandboxGlobals: {
-    BACKEND_URL: "http://backend",
-   }
+  log: true,
+  buildSandboxGlobals(defaultGlobals) {
+    return Object.assign(
+      {},
+      defaultGlobals,
+        {BACKEND_URL: "http://backend"}
+    );
+  },
 });
 
 fastbootAppServer.start();

--- a/server/server.js
+++ b/server/server.js
@@ -1,23 +1,6 @@
 const fs  = require('fs');
 const FastbootAppServer = require('fastboot-app-server');
 
-// Docker Enviroment Variables
-const PREFIX = "EMBER_";
-const EMBER_CONFIG = Object.entries(process.env)
-      .filter(([key]) => key.indexOf(PREFIX) === 0)
-      .map(([key, value]) => [key.slice(PREFIX.length), value]);
-
-let indexHtml = fs.readFileSync("/app/index.html", "utf8");
-let packageJson = fs.readFileSync("/app/package.json", "utf8");
-for (const [key, value] of EMBER_CONFIG) {
-  console.log(`Replacing name ${key} with value ${value}`);
-  packageJson = packageJson.replace( new RegExp(`{{${key}}}`, "g"), value);
-  indexHtml = indexHtml.replace( new RegExp(`{{${key}}}`, "g"), encodeURIComponent(value) );
-  indexHtml = indexHtml.replace( new RegExp(`%7B%7B${key}%7D%7D`, "g"), encodeURIComponent(value) );
-}
-fs.writeFileSync("/app/index.html", indexHtml);
-fs.writeFileSync("app/package.json", packageJson);
-
 let fastbootAppServer = new FastbootAppServer({
   port: 80,
   distPath: "/app/",


### PR DESCRIPTION
fastbootserver forks the node process and causes the replacement to happen in
parrallel, which causes a possible race condition resulting in a broken
package.json file. by executing the replacement in a sh script we avoid this

fasboot bumped from 2.x to 3.3, see  changelog on https://github.com/ember-fastboot/ember-cli-fastboot/blob/master/CHANGELOG.md