### PR TITLE
feat(node): bump node to 18

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:14
+FROM node:18
 
 ADD ./server/ /usr/src/app
 RUN cd /usr/src/app/; npm install


### PR DESCRIPTION
Bump the node base image to 18

reasoning: node 14 and 16 are no longer supported as per [the official docs](https://nodejs.org/en/about/previous-releases). I'd be happy to bump this to 20, the current lts release, but I feel like there's a convention to be a bit slow with node releases.