### PR TITLE
feat: use the app's fastboot config if it exists

### DIFF
--- a/README.md
+++ b/README.md
@@ -228,7 +228,7 @@ module.exports = function () {
 
 ```
 
-``` dockerfile
+``` diff
 
   FROM madnificent/ember:4.12.1-node_18 as builder
 
@@ -264,12 +264,12 @@ let fastbootAppServer = new FastbootAppServer({
         {BACKEND_URL: "http://backend"}
     );
   },
-  ...customConfig // your config,
+  ...customConfig // this is where your config gets included
 });
 
 ```
 
 > [!WARNING]  
-> If you override the buildSandboxGlobals function, you should probably include the BACKEND_URL like in the example above, since it allows fastboot to find your backend in a docker-compose 
+> If you override the `buildSandboxGlobals` function, you should probably include the `BACKEND_URL` like in the example above, since it allows fastboot to find your backend in a docker-compose 
 > setup. 
 

--- a/README.md
+++ b/README.md
@@ -207,3 +207,69 @@ services:
     environment:
       EMBER_FASTBOOT_HOST: "my.app-domain.org"
 ```
+### Customize the fastboot settings
+
+You may have special settings you want to pass to fastboot. This is done by adding a `config/fastboot.js` file to your app and copying it over to the fastboot server container.
+
+e.g.:
+
+``` javascript
+// config/fastboot.js
+module.exports = function () {
+  return {
+    buildSandboxGlobals(defaultGlobals) {
+      return Object.assign({}, defaultGlobals, {
+        SOME_CUSTOM_GLOBAL: "foo",
+        BACKEND_URL: "http://backend"
+      });
+    },
+  };
+};
+
+```
+
+``` dockerfile
+
+  FROM madnificent/ember:4.12.1-node_18 as builder
+
+  LABEL maintainer="info@redpencil.io"
+
+  WORKDIR /app
+  COPY package.json .
+  RUN npm install
+  COPY . .
+  RUN ember build --environment production
+
+  FROM redpencil/fastboot-app-server
+  COPY --from=builder /app/dist /app
++ COPY --from=builder /app/config/fastboot.js /app
+```
+
+
+If you export a function, it will be called, and the resulting object will be spread out onto the
+default config. If it's an object, it will be used directly:
+
+
+``` javascript
+let fastbootAppServer = new FastbootAppServer({
+  port: 80,
+  distPath: "/app/",
+  chunkedResponse: false,
+  gzip: true,
+  log: true,
+  buildSandboxGlobals(defaultGlobals) {
+    return Object.assign(
+      {},
+      defaultGlobals,
+        {BACKEND_URL: "http://backend"}
+    );
+  },
+  ...customConfig // your config,
+});
+
+```
+
+> [!WARNING]  
+> If you override the buildSandboxGlobals function, you should probably include the BACKEND_URL like in the example above, since it allows fastboot to find your backend in a docker-compose 
+> setup. 
+

--- a/server/server.js
+++ b/server/server.js
@@ -1,4 +1,19 @@
 const FastbootAppServer = require('fastboot-app-server');
+let config;
+try {
+  config = require("/app/fastboot");
+} catch (e) {
+  console.info("No fastboot config found in the app, using default");
+}
+let customConfig = {};
+
+if (config) {
+  if (typeof config === "function") {
+    customConfig = config();
+  } else if (typeof config === "object") {
+    customConfig = config;
+  }
+}
 
 let fastbootAppServer = new FastbootAppServer({
   port: 80,
@@ -25,6 +40,7 @@ let fastbootAppServer = new FastbootAppServer({
       BACKEND_URL: "http://backend",
     });
   },
+  ...customConfig,
 });
 
 fastbootAppServer.start();


### PR DESCRIPTION
Incorporate the app's `fastboot.js` config if it exists and let it override defaults.

#### Reasoning

Apps may have unpredictable requirements, having an escape hatch for the config can be useful.